### PR TITLE
feat: Implement ephemeral links and settings modal

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import * as RadixSwitch from '@radix-ui/react-switch'; // Import Switch from Radix UI
-import { Cross2Icon } from '@radix-ui/react-icons';
+import { Icon } from '@iconify/react/dist/iconify.js'; // Import Iconify
 import { Flex, Text } from '@radix-ui/themes'; // Import Flex and Text from Radix Themes
 import { useLocalStorage } from 'usehooks-ts'; // Import useLocalStorage
 
@@ -50,7 +50,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ open, onOpenChange }) => 
               className="absolute top-3 right-3 inline-flex h-6 w-6 items-center justify-center rounded-full bg-transparent text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-300" 
               aria-label="Close"
             >
-              <Cross2Icon />
+              <Icon icon="bx:x" />
             </button>
           </Dialog.Close>
         </Dialog.Content>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import * as RadixSwitch from '@radix-ui/react-switch'; // Import Switch from Radix UI
+import { Cross2Icon } from '@radix-ui/react-icons';
+import { Flex, Text } from '@radix-ui/themes'; // Import Flex and Text from Radix Themes
+import { useLocalStorage } from 'usehooks-ts'; // Import useLocalStorage
+
+interface SettingsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const SettingsModal: React.FC<SettingsModalProps> = ({ open, onOpenChange }) => {
+  const [createEphemeralLinks, setCreateEphemeralLinks] = useLocalStorage(
+    'createEphemeralLinksByDefault',
+    false
+  );
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/40 data-[state=open]:animate-overlayShow" />
+        <Dialog.Content className="fixed top-1/2 left-1/2 w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-md bg-white p-6 shadow-lg focus:outline-none data-[state=open]:animate-contentShow max-h-[85vh] overflow-y-auto">
+          <Dialog.Title className="mb-4 text-lg font-medium text-neutral-900">
+            Application Settings
+          </Dialog.Title>
+          
+          <Flex align="center" justify="between" className="mt-4 py-2">
+            <Text size="2" as="label" htmlFor="ephemeral-switch" className="text-gray-700 select-none">
+              Create ephemeral links by default
+            </Text>
+            <RadixSwitch.Root
+              id="ephemeral-switch"
+              checked={createEphemeralLinks}
+              onCheckedChange={setCreateEphemeralLinks}
+              className="relative h-[25px] w-[42px] cursor-pointer rounded-full bg-gray-300 shadow-sm outline-none data-[state=checked]:bg-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"
+            >
+              <RadixSwitch.Thumb className="block h-[21px] w-[21px] translate-x-0.5 transform rounded-full bg-white shadow-sm transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[19px]" />
+            </RadixSwitch.Root>
+          </Flex>
+
+          <div className="my-5 border-t pt-4 mt-4"> {/* Added some separation */}
+            Settings content will go here.
+            <br />
+            Theme selection (coming soon)
+          </div>
+
+          <Dialog.Close asChild>
+            <button 
+              className="absolute top-3 right-3 inline-flex h-6 w-6 items-center justify-center rounded-full bg-transparent text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-300" 
+              aria-label="Close"
+            >
+              <Cross2Icon />
+            </button>
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
+export default SettingsModal;

--- a/src/pages/[slug].tsx
+++ b/src/pages/[slug].tsx
@@ -21,9 +21,18 @@ export const getServerSideProps = async ({req, res}: {
     const url = await caller.urls.getLink({ id: req.url?.slice(1) ?? "" as string });
     console.log("FIND LONG URL", url)
     if (url) {
+      if (url.isEphemeral) {
+        try {
+          // Optional log: console.log(`Link ${url.shortUrl} is ephemeral, attempting deletion after use.`);
+          await caller.urls.deleteLinkAfterUse({ shortUrl: url.shortUrl });
+        } catch (deleteError) {
+          console.error(`Failed to delete ephemeral link ${url.shortUrl} after use:`, deleteError);
+          // Log the error, but do not block the redirect.
+        }
+      }
       return {
         redirect: {
-          destination: url.url ?? '/404',
+          destination: url.url ?? '/404', // Fallback to /404 if url.url is somehow null
           permanent: false,
         },
       }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,7 +17,7 @@ import { signIn, signOut, useSession } from "next-auth/react";
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { type url } from "~/types/url";
 import { useForm, type SubmitHandler } from "react-hook-form";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import getRandomRadixColor from "~/utils/color";
 import Head from "next/head";
 import toast from "react-hot-toast";
@@ -27,6 +27,7 @@ import { env } from "~/env";
 import Link from "next/link";
 import Image from "next/image";
 import t3logo from "../../public/t3-light.png";
+import SettingsModal from '~/components/SettingsModal';
 const GeneratedURLs = dynamic(() => import('~/components/GeneratedURLs'), { ssr: false })
 
 
@@ -79,6 +80,8 @@ export default function Home({ userGeneratedLinks }: IProps) {
 
   // const [links, setLinks] = useState<url[]>(userGeneratedLinks ?? []);
   const [userLinks, setUserLinks, removeUserLinks] = useLocalStorage("links", userGeneratedLinks ?? []);
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+  const [createEphemeralLinksByDefault] = useLocalStorage('createEphemeralLinksByDefault', false);
 
   const [copiedText, copy] = useCopyToClipboard()
 
@@ -132,6 +135,7 @@ export default function Home({ userGeneratedLinks }: IProps) {
     createLinkMutation.mutate(
       {
         longUrl: data.url,
+        isEphemeral: createEphemeralLinksByDefault,
       },
       {
         onSuccess: (data) => {
@@ -262,7 +266,7 @@ export default function Home({ userGeneratedLinks }: IProps) {
             <IconButton
               color="gray"
               variant="outline"
-              onClick={() => signIn()}
+              onClick={() => setIsSettingsModalOpen(true)}
             >
               <Icon icon="bx:cog" />
             </IconButton>
@@ -346,7 +350,7 @@ export default function Home({ userGeneratedLinks }: IProps) {
             </Link>
           </IconButton>
         </Flex>
-
+        <SettingsModal open={isSettingsModalOpen} onOpenChange={setIsSettingsModalOpen} />
       </main>
     </>
   );

--- a/src/server/api/routers/urls.ts
+++ b/src/server/api/routers/urls.ts
@@ -20,7 +20,7 @@ export const urlRouter = createTRPCRouter({
     }),
 
   create: rateLimitedProcedure
-    .input(z.object({ longUrl: z.string().min(8) }))
+    .input(z.object({ longUrl: z.string().min(8), isEphemeral: z.boolean().optional() }))
     .mutation(async ({ ctx, input }) => {
       let shortUrl = generateShortLink();
       const consult = await ctx.db.query.urls.findFirst({
@@ -36,6 +36,7 @@ export const urlRouter = createTRPCRouter({
           url: input.longUrl,
           shortUrl: shortUrl,
           userId: userId ?? null,
+          isEphemeral: input.isEphemeral ?? false,
           expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7),
         })
         .returning();
@@ -81,4 +82,20 @@ export const urlRouter = createTRPCRouter({
   getSecretMessage: protectedProcedure.query(() => {
     return "you can now see this secret message!";
   }),
+
+  deleteLinkAfterUse: publicProcedure
+    .input(z.object({ shortUrl: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await ctx.db.delete(urls).where(eq(urls.shortUrl, input.shortUrl));
+        // Optional: server-side log
+        // console.log(`Ephemeral link ${input.shortUrl} deleted after use.`);
+      } catch (error) {
+        // console.error(`Error deleting ephemeral link ${input.shortUrl}:`, error);
+        // Do not re-throw, as redirect is more critical.
+        // If the link was already deleted or never existed, this will likely not throw.
+        // If there's a DB connection issue, it might throw.
+      }
+      return { success: true }; // Or simply return void
+    }),
 });

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,5 +1,6 @@
 import { relations, sql } from "drizzle-orm";
 import {
+  boolean,
   index,
   integer,
   pgTableCreator,
@@ -26,6 +27,7 @@ export const urls = createTable(
     url: varchar("url", { length: 255 }).notNull(),
     shortUrl: varchar("shortUrl", { length: 7 }).notNull(),
     userId: varchar("userId", { length: 255 }),
+    isEphemeral: boolean("is_ephemeral").default(false).notNull(),
     createdAt: timestamp("created_at")
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),


### PR DESCRIPTION
This commit introduces several enhancements:

1.  **Fixes Settings Button:** The settings button in the header no longer incorrectly redirects to Discord login. It now opens the newly implemented settings modal.

2.  **Adds Settings Modal:**
    - A basic settings modal has been created using Radix UI Dialog.
    - Styling for the modal is handled by Tailwind CSS.
    - Includes a toggle for the "ephemeral links" feature.

3.  **Implements Ephemeral Links Feature:**
    - **Database:** The `urls` table schema now includes an `isEphemeral` boolean flag (defaulting to false).
    - **Settings UI:** You can toggle a setting in the new modal ("Create ephemeral links by default") to have newly generated links be ephemeral. This preference is stored in local storage.
    - **Link Creation:**
        - The backend API for link creation now accepts an `isEphemeral` flag.
        - The client-side link shortening logic now sends this flag based on your preference from the settings modal.
    - **Link Redirection & Deletion:** - When an ephemeral link is accessed, it redirects to the target URL as expected. - After the first successful use, the ephemeral link is automatically deleted from the database. - A new tRPC mutation (`deleteLinkAfterUse`) handles this server-side deletion.

All core functionality related to link shortening and redirection has been tested in conjunction with these new features.